### PR TITLE
Add 'Move-In Checklist' category tag to grader checks

### DIFF
--- a/.gatorgrade.yml
+++ b/.gatorgrade.yml
@@ -1,32 +1,37 @@
 # BASE DIR
 - ./:
   - nameplate.md:
-    - description: Customize the nameplate (no TODOs)
+    - description: Customize the nameplate (no TODO markers remaining)
+      category: Move-In Checklist
       check: MatchFileFragment
       options:
         fragment: TODO
         count: 0
         exact: true
 # ITEMS <-- TODO: write flags for object locations
-- description: Find the Ink hidden in the couch
+- description: Find the Ink needed to print the lease
+  category: Move-In Checklist
   check: CountCommandOutput
   options:
     count: 1
     command: find . -name Ink.py
 - description: Print the lease
+  category: Move-In Checklist
   check: CountCommandOutput
   options:
     count: 1
     command: find . -name Lease.md
 # EVENTS
 - description: Enter the house
+  category: Move-In Checklist
   check: MatchCommandFragment
   options:
     fragment: "null"
     count: 0
     exact: true
     command: jq .kitchen .flags
-- description: Read the note
+- description: Read the Note in the living-room
+  category: Move-In Checklist
   check: MatchCommandFragment
   options:
     fragment: "null"
@@ -35,30 +40,35 @@
     command: jq .note_read .flags
 # BOXES
 - description: Open the UltraHeavyBox
+  category: Move-In Checklist
   check: CountCommandOutput
   options:
     command: ls -l living-room/dining-room/kitchen/UltraHeavyBox.py
     count: 0
     exact: true
 - description: Open the FragileBox
+  category: Move-In Checklist
   check: CountCommandOutput
   options:
     command: ls -l living-room/dining-room/FragileBox.py
     count: 0
     exact: true
 - description: Open the SinisterLookingBox
+  category: Move-In Checklist
   check: CountCommandOutput
   options:
     command: ls -l living-room/hallway/bedroom/SinisterLookingBox.py
     count: 0
     exact: true
 - description: Open the TubeShapedBox
+  category: Move-In Checklist
   check: CountCommandOutput
   options:
     command: ls -l living-room/hallway/bedroom/TubeShapedBox.py
     count: 0
     exact: true
 - description: Open the BeatUpBox
+  category: Move-In Checklist
   check: CountCommandOutput
   options:
     command: ls -l living-room/hallway/office/BeatUpBox.py


### PR DESCRIPTION
Bit of a punt, but because `house` is so different, it seemed like the most sense to just group all of the grader checks into a singular "Move-In Checklist" category.

Alternatively, I could split off the five moving boxes into one category, have the nameplate in its own category, and then just a miscellaneous category for checks like entering the house and finding the ink...but that didn't feel quite right, either. Let me know if you prefer this second division for the `house` assignment (or some other proposed category classification) and I'll adjust accordingly.