### PR TITLE
Add updated reflection document

### DIFF
--- a/living-room/hallway/bedroom/reflection.md
+++ b/living-room/hallway/bedroom/reflection.md
@@ -1,0 +1,64 @@
+# BASIC ITEMIZED GUIDE for BRIEFING RECENT OPERATIONS
+
+**THE USE OF THIS FORM FOR DATA COLLECTION REGARDING ALL `term-world` OPERATIONS IS AUTHORIZED BY THE OFFICE OF THE MAYOR.**
+
+**SUGGESTIONS REGARDING THE FORM'S UTILITY OR CONCERNS ABOUT THE QUESTIONS CONTAINED HEREIN OUGHT TO BE DIRECTED TO THE OFFICE OF THE MAYOR VIA ESTABLISHED FORMAL PROPOSAL METHODS.**
+
+
+## OPERATOR INFORMATION:
+
+*Please write your name below*
+
+### Name: TODO
+
+The above operator formally attests to the following
+(*please mark all applicable checkboxes with an `X`*):
+
+- [ ] I adhered to the `term-world` Code of Conduct concerning all `term-world` operations
+- [ ] I stand by the quality of my work
+- [ ] I participated in the completion of an operation
+that I fully believe to be for the good of `term-world`
+and all of its citizens
+
+**NOTE: SATISFACTORY COMPLETION OF THIS FORM REQUIRES ALL
+ABOVE CHECKBOXES TO BE CHECKED.**
+
+
+## BASIC OPERATIONS CHARACTERISTICS
+
+*Please answer all below questions pertaining to the basic premises of the operations being briefed.*
+
+### To your understanding, what was the goal of this week's work?
+
+TODO
+
+### In your own words, define the following terms/ideas:
+
+- Terminal: TODO
+
+- GitHub: TODO
+
+
+## ANALYSIS OF OPERATIONAL APPLICATION
+
+*Please answer all below questions pertaining to a higher-level analysis of the operations being briefed and their related ideas.*
+
+### Compare GitHub to a real-world fixture (like a post office, a school, or a library). In what ways are they similar?
+
+TODO
+
+
+## EVALUATIVE QUESTIONNAIRE
+
+*Please answer all below questions pertaining to an evaluation of the operations being briefed.*
+
+### What aspects of either GitHub or terminal navigation do you still find challenging to use or understand?
+
+TODO
+
+### As you've experienced it thus far, what attributes make `term-world` like or unlike the real world?
+
+TODO
+
+
+**YOUR MAYOR THANKS YOU FOR TAKING THE TIME TO FILL OUT THIS BASIC ITEMIZED GUIDE FOR BRIEFING RECENT OPERATIONS.**

--- a/living-room/hallway/bedroom/reflection.md
+++ b/living-room/hallway/bedroom/reflection.md
@@ -18,8 +18,7 @@ The above operator formally attests to the following
 - [ ] I stand by the quality of my work
 - [ ] I participated in the completion of an operation that I fully believe to be for the good of `term-world` and all of its citizens
 
-**NOTE: SATISFACTORY COMPLETION OF THIS FORM REQUIRES ALL
-ABOVE CHECKBOXES TO BE CHECKED.**
+**NOTE: SATISFACTORY COMPLETION OF THIS FORM REQUIRES ALL ABOVE CHECKBOXES TO BE CHECKED.**
 
 
 ## BASIC OPERATIONS CHARACTERISTICS

--- a/living-room/hallway/bedroom/reflection.md
+++ b/living-room/hallway/bedroom/reflection.md
@@ -16,9 +16,7 @@ The above operator formally attests to the following
 
 - [ ] I adhered to the `term-world` Code of Conduct concerning all `term-world` operations
 - [ ] I stand by the quality of my work
-- [ ] I participated in the completion of an operation
-that I fully believe to be for the good of `term-world`
-and all of its citizens
+- [ ] I participated in the completion of an operation that I fully believe to be for the good of `term-world` and all of its citizens
 
 **NOTE: SATISFACTORY COMPLETION OF THIS FORM REQUIRES ALL
 ABOVE CHECKBOXES TO BE CHECKED.**


### PR DESCRIPTION
This implements the first take on the new narrative-supported reflection document, the Basic Itemized Guide for Briefing Recent Operations (the BIG-BRO).

I propose four categories to fill out:
- A simple checkbox-driven "did you follow the code of conduct" questionnaire (with some narrative oomph)
- A basic overview of the week's "operations" asking questions related to *remember* and *understand* portions of the Bloom taxonomy
- A higher-level analysis of ideas related to the week's operations (for *apply* and *analyze*)
- A final evaluative section asking students to form a claim (for the *evaluate* portion of the taxonomy)